### PR TITLE
Enhanced regexp to better match python files

### DIFF
--- a/pylint_web2py2/__init__.py
+++ b/pylint_web2py2/__init__.py
@@ -141,7 +141,7 @@ Add models path too to be able to import it from the fake code
     def _fill_app_model_names(self, app_models_path):
         'Save model names for later use'
         model_files = os.listdir(app_models_path)
-        model_files = [model_file for model_file in model_files if re.match(r'.+?\.py', model_file)] #Only top-level models
+        model_files = [model_file for model_file in model_files if re.match(r'.+?\.py$', model_file)] #Only top-level models
         model_files = sorted(model_files) #Models are executed in alphabetical order
         self.app_model_names = [re.match(r'^(.+?)\.py$', model_file).group(1) for model_file in model_files]
 


### PR DESCRIPTION
I've run in an issue with this plugin where other files were present in models dir (backup files with *.py.bak pattern). Changing the regex at line 144 fixes the issue.